### PR TITLE
Add __getitem__ to Result class

### DIFF
--- a/brigade/core/task.py
+++ b/brigade/core/task.py
@@ -65,6 +65,12 @@ class Result(object):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+    def __getitem__(self, item):
+        try:
+            return self.__dict__[item]
+        except KeyError:
+            raise
+
 
 class AggregatedResult(dict):
     """


### PR DESCRIPTION
Ran into an issue after the results was swapped out to an object.

(brigade3) ~/src/playground/brigade-tests/demo  ᐅ python do.py
Traceback (most recent call last):
  File "do.py", line 97, in <module>
    deploy()
  File "do.py", line 89, in deploy
    filtered.run(task=base_config)
  File "/Users/patrick/src/forks/brigade/brigade/core/__init__.py", line 132, in run
    result.raise_on_error()
  File "/Users/patrick/src/forks/brigade/brigade/core/task.py", line 93, in raise_on_error
    raise BrigadeExecutionError(self)
brigade.core.exceptions.BrigadeExecutionError: ok: {}, failed:{'switch00.cmh': TypeError("'Result' object is not subscriptable",), 'switch01.cmh': TypeError("'Result' object is not subscriptable",)}

