### PR TITLE
[bugfix] - `filter` method fails if a host doesn't have one of the filtering keys

### DIFF
--- a/brigade/core/inventory.py
+++ b/brigade/core/inventory.py
@@ -1,4 +1,3 @@
-import uuid
 from multiprocessing import Manager
 
 from brigade.core import helpers
@@ -204,7 +203,6 @@ class Inventory(object):
             filtered = {n: h for n, h in self.hosts.items()
                         if filter_func(h, **kwargs)}
         else:
-            no_match = uuid.uuid4()
             filtered = {n: h for n, h in self.hosts.items()
-                        if all(h.get(k, no_match) == v for k, v in kwargs.items())}
+                        if all(h.get(k) == v for k, v in kwargs.items())}
         return Inventory(hosts=filtered, groups=self.groups, data=self.data)

--- a/brigade/core/inventory.py
+++ b/brigade/core/inventory.py
@@ -107,7 +107,15 @@ class Host(object):
     def __repr__(self):
         return "{}: {}".format(self.__class__.__name__, self.name)
 
-    def _getitem_or_no_match(self, item, no_match):
+    def get(self, item, default=None):
+        """
+        Returns the value ``item`` from the host or hosts group variables.
+
+        Arguments:
+            item(``str``): The variable to get
+            default(``any``): Return value if item not found
+
+        """
         try:
             return self.data[item]
         except KeyError:
@@ -116,7 +124,7 @@ class Host(object):
                     return self.group[item]
             except KeyError:
                 pass
-            return no_match
+            return default
 
     def items(self):
         """
@@ -203,5 +211,5 @@ class Inventory(object):
         else:
             no_match = uuid.uuid4()
             filtered = {n: h for n, h in self.hosts.items()
-                        if all(h._getitem_or_no_match(k, no_match) == v for k, v in kwargs.items())}
+                        if all(h.get(k, no_match) == v for k, v in kwargs.items())}
         return Inventory(hosts=filtered, groups=self.groups, data=self.data)

--- a/brigade/core/inventory.py
+++ b/brigade/core/inventory.py
@@ -117,13 +117,8 @@ class Host(object):
 
         """
         try:
-            return self.data[item]
+            return self.__getitem__(item)
         except KeyError:
-            try:
-                if self.group:
-                    return self.group[item]
-            except KeyError:
-                pass
             return default
 
     def items(self):

--- a/tests/core/inventory_data/hosts.yaml
+++ b/tests/core/inventory_data/hosts.yaml
@@ -2,6 +2,7 @@
 host1.group_1:
     group: group_1
     my_var: comes_from_host1.group_1
+    comment: web
     role: www
 
 host2.group_1:
@@ -10,6 +11,7 @@ host2.group_1:
 
 host3.group_2:
     group: group_2
+    comment: web
     role: www
 
 host4.group_2:

--- a/tests/core/inventory_data/hosts.yaml
+++ b/tests/core/inventory_data/hosts.yaml
@@ -2,7 +2,7 @@
 host1.group_1:
     group: group_1
     my_var: comes_from_host1.group_1
-    comment: web
+    www_server: nginx
     role: www
 
 host2.group_1:
@@ -11,7 +11,7 @@ host2.group_1:
 
 host3.group_2:
     group: group_2
-    comment: web
+    www_server: apache
     role: www
 
 host4.group_2:

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -38,8 +38,8 @@ class Test(object):
         assert long_names == ['host1.group_1', 'host4.group_2']
 
     def test_filter_unique_keys(self):
-        filtered = sorted(list(inventory.filter(comment='web').hosts.keys()))
-        assert filtered == ['host1.group_1', 'host3.group_2']
+        filtered = sorted(list(inventory.filter(www_server='nginx').hosts.keys()))
+        assert filtered == ['host1.group_1']
 
     def test_var_resolution(self):
         assert inventory.hosts["host1.group_1"]["my_var"] == "comes_from_host1.group_1"

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -37,6 +37,10 @@ class Test(object):
             filter_func=longer_than, length=20).hosts.keys()))
         assert long_names == ['host1.group_1', 'host4.group_2']
 
+    def test_filter_unique_keys(self):
+        filtered = sorted(list(inventory.filter(comment='web').hosts.keys()))
+        assert filtered == ['host1.group_1', 'host3.group_2']
+
     def test_var_resolution(self):
         assert inventory.hosts["host1.group_1"]["my_var"] == "comes_from_host1.group_1"
         assert inventory.hosts["host2.group_1"]["my_var"] == "comes_from_group_1"


### PR DESCRIPTION
The current filter function requires that the filters being used are defined on all of the hosts in the inventory.

