### PR TITLE
Add `num_workers` argument to `run()`

### DIFF
--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -126,8 +126,7 @@ class Brigade(object):
         Returns:
             :obj:`brigade.core.task.AggregatedResult`: results of each execution
         """
-        if not num_workers:
-            num_workers = self.num_workers
+        num_workers = num_workers or self.num_workers
 
         if num_workers == 1:
             result = self._run_serial(task, **kwargs)


### PR DESCRIPTION
Some tasks might have to run in serial, this change allowes a user to
change the number of workers for a specific task without changing the
value of Brigade.num_workers