### PR TITLE
For discussion - Add config class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/ref/configuration/generated/*.rst
 
 # PyBuilder
 target/

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -43,25 +43,20 @@ class Brigade(object):
     Arguments:
         inventory (:obj:`brigade.core.inventory.Inventory`): Inventory to work with
         dry_run(``bool``): Whether if we are testing the changes or not
-        num_workers(``int``): How many hosts run in parallel
-        raise_on_error (``bool``): If set to ``True``, :meth:`run` method of will
-          raise an exception if at least a host failed.
+        config (:obj:`brigade.core.configuration.Config`): Configuration object
+        config_file (``str``): Path to Yaml configuration file
 
     Attributes:
         inventory (:obj:`brigade.core.inventory.Inventory`): Inventory to work with
         dry_run(``bool``): Whether if we are testing the changes or not
-        num_workers(``int``): How many hosts run in parallel
-        raise_on_error (``bool``): If set to ``True``, :meth:`run` method of will
-          raise an exception if at least a host failed.
+        config (:obj:`brigade.core.configuration.Config`): Configuration parameters
     """
 
-    def __init__(self, inventory, dry_run, num_workers=20, raise_on_error=True,
+    def __init__(self, inventory, dry_run,
                  config=None, config_file=None):
         self.inventory = inventory
 
         self.dry_run = dry_run
-        self.num_workers = num_workers
-        self.raise_on_error = raise_on_error
         if config_file:
             self.config = Config(config_file=config_file)
         else:
@@ -129,19 +124,19 @@ class Brigade(object):
 
         Raises:
             :obj:`brigade.core.exceptions.BrigadeExceptionError`: if at least a task fails
-              and self.raise_on_error is set to ``True``
+              and self.config.raise_on_error is set to ``True``
 
         Returns:
             :obj:`brigade.core.task.AggregatedResult`: results of each execution
         """
-        num_workers = num_workers or self.num_workers
+        num_workers = num_workers or self.config.num_workers
 
         if num_workers == 1:
             result = self._run_serial(task, **kwargs)
         else:
             result = self._run_parallel(task, num_workers, **kwargs)
 
-        if self.raise_on_error:
+        if self.config.raise_on_error:
             result.raise_on_error()
         return result
 

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -4,6 +4,7 @@ import traceback
 from multiprocessing.dummy import Pool
 
 from brigade.core.task import AggregatedResult, Task
+from brigade.core.configuration import Config
 
 
 if sys.version_info.major == 2:
@@ -54,12 +55,14 @@ class Brigade(object):
           raise an exception if at least a host failed.
     """
 
-    def __init__(self, inventory, dry_run, num_workers=20, raise_on_error=True):
+    def __init__(self, inventory, dry_run, num_workers=20, raise_on_error=True,
+                 config=None):
         self.inventory = inventory
 
         self.dry_run = dry_run
         self.num_workers = num_workers
         self.raise_on_error = raise_on_error
+        self.config = config or Config()
 
         format = "\033[31m%(asctime)s - %(name)s - %(levelname)s"
         format += " - %(funcName)20s() - %(message)s\033[0m"

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -3,8 +3,8 @@ import sys
 import traceback
 from multiprocessing.dummy import Pool
 
-from brigade.core.task import AggregatedResult, Task
 from brigade.core.configuration import Config
+from brigade.core.task import AggregatedResult, Task
 
 
 if sys.version_info.major == 2:
@@ -56,13 +56,16 @@ class Brigade(object):
     """
 
     def __init__(self, inventory, dry_run, num_workers=20, raise_on_error=True,
-                 config=None):
+                 config=None, config_file=None):
         self.inventory = inventory
 
         self.dry_run = dry_run
         self.num_workers = num_workers
         self.raise_on_error = raise_on_error
-        self.config = config or Config()
+        if config_file:
+            self.config = Config(config_file=config_file)
+        else:
+            self.config = config or Config()
 
         format = "\033[31m%(asctime)s - %(name)s - %(levelname)s"
         format += " - %(funcName)20s() - %(message)s\033[0m"

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -7,7 +7,9 @@ import yaml
 
 CONF = {
     'num_workers': {
-        'description': 'Number of Brigade worker processes',
+        'description': 'Number of Brigade worker processes that are run at the same time, '
+                       'configuration can be overridden on individual tasks by using the '
+                       '`num_workers` argument to (:obj:`brigade.core.Brigade.run`)',
         'type': 'int',
         'default': 20,
     },
@@ -27,14 +29,16 @@ CONF = {
 
 types = {
     'int': int,
-    'str': str
+    'str': str,
 }
 
 
 class Config:
     """
-    Documentation
+    This object handles the configuration of Brigade.
 
+    Arguments:
+        config_file(``str``): Yaml configuration file.
     """
 
     def __init__(self, config_file=None):
@@ -51,7 +55,6 @@ class Config:
 
         for p in CONF:
             env = CONF[p].get('env') or 'BRIGADE_' + p.upper()
-            print(env)
             if CONF[p]['type'] == 'bool':
                 if os.environ.get(env) is not None:
                     v = os.environ.get(env)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -1,0 +1,16 @@
+import os
+
+c = {
+    'ssh_config_file': os.environ.get('BRIGADE_SSH_CONFIG_FILE') or
+    os.path.join(os.path.expanduser("~"), ".ssh", "config"),
+}
+
+
+class Config:
+    """
+    Documentation
+
+    """
+
+    def __init__(self):
+        self.ssh_config_file = c['ssh_config_file']

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -55,15 +55,10 @@ class Config:
 
         for p in CONF:
             env = CONF[p].get('env') or 'BRIGADE_' + p.upper()
+            v = os.environ.get(env) or c.get(p)
+            v = v if v is not None else CONF[p]['default']
             if CONF[p]['type'] == 'bool':
-                if os.environ.get(env) is not None:
-                    v = os.environ.get(env)
-                elif c.get(p) is not None:
-                    v = c.get(p)
-                else:
-                    v = CONF[p]['default']
                 v = ast.literal_eval(str(v).title())
             else:
-                v = os.environ.get(env) or c.get(p) or CONF[p]['default']
                 v = types[CONF[p]['type']](v)
             setattr(self, p, v)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -9,22 +9,28 @@ CONF = {
     'num_workers': {
         'description': 'Number of Brigade worker processes',
         'env': 'BRIGADE_NUM_WORKERS',
-        'type': int,
+        'type': 'int',
         'default': 20,
     },
     'raise_on_error': {
-        'description': "If set to ``True``, :meth:`run` method of will raise an exception if at "
-                       "least a host failed.",
+        'description': "If set to ``True``, (:obj:`brigade.core.Brigade.run`) method of will raise "
+                       "an exception if at least a host failed.",
         'env': 'BRIGADE_RAISE_ON_ERROR',
-        'type': bool,
+        'type': 'bool',
         'default': True,
     },
     'ssh_config_file': {
         'description': 'User ssh_config_file',
         'env': 'BRIGADE_SSH_CONFIG_FILE',
-        'type': str,
+        'type': 'str',
         'default': os.path.join(os.path.expanduser("~"), ".ssh", "config"),
+        'default_doc': '~/.ssh/config'
     },
+}
+
+types = {
+    'int': int,
+    'str': str
 }
 
 
@@ -47,7 +53,7 @@ class Config:
     def _assign_properties(self, c):
 
         for p in CONF:
-            if CONF[p]['type'] == bool:
+            if CONF[p]['type'] == 'bool':
                 if os.environ.get(CONF[p]['env']) is not None:
                     v = os.environ.get(CONF[p]['env'])
                 elif c.get(p) is not None:
@@ -57,5 +63,5 @@ class Config:
                 v = ast.literal_eval(str(v).title())
             else:
                 v = os.environ.get(CONF[p]['env']) or c.get(p) or CONF[p]['default']
-                v = CONF[p]['type'](v)
+                v = types[CONF[p]['type']](v)
             setattr(self, p, v)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -8,20 +8,17 @@ import yaml
 CONF = {
     'num_workers': {
         'description': 'Number of Brigade worker processes',
-        'env': 'BRIGADE_NUM_WORKERS',
         'type': 'int',
         'default': 20,
     },
     'raise_on_error': {
         'description': "If set to ``True``, (:obj:`brigade.core.Brigade.run`) method of will raise "
                        "an exception if at least a host failed.",
-        'env': 'BRIGADE_RAISE_ON_ERROR',
         'type': 'bool',
         'default': True,
     },
     'ssh_config_file': {
         'description': 'User ssh_config_file',
-        'env': 'BRIGADE_SSH_CONFIG_FILE',
         'type': 'str',
         'default': os.path.join(os.path.expanduser("~"), ".ssh", "config"),
         'default_doc': '~/.ssh/config'
@@ -53,15 +50,17 @@ class Config:
     def _assign_properties(self, c):
 
         for p in CONF:
+            env = CONF[p].get('env') or 'BRIGADE_' + p.upper()
+            print(env)
             if CONF[p]['type'] == 'bool':
-                if os.environ.get(CONF[p]['env']) is not None:
-                    v = os.environ.get(CONF[p]['env'])
+                if os.environ.get(env) is not None:
+                    v = os.environ.get(env)
                 elif c.get(p) is not None:
                     v = c.get(p)
                 else:
                     v = CONF[p]['default']
                 v = ast.literal_eval(str(v).title())
             else:
-                v = os.environ.get(CONF[p]['env']) or c.get(p) or CONF[p]['default']
+                v = os.environ.get(env) or c.get(p) or CONF[p]['default']
                 v = types[CONF[p]['type']](v)
             setattr(self, p, v)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -1,16 +1,28 @@
+import ast
 import os
+
+
 import yaml
 
 
 CONF = {
     'num_workers': {
         'description': 'Number of Brigade worker processes',
-        'environment': 'BRIGADE_NUM_WORKERS',
+        'env': 'BRIGADE_NUM_WORKERS',
+        'type': int,
         'default': 20,
+    },
+    'raise_on_error': {
+        'description': "If set to ``True``, :meth:`run` method of will raise an exception if at "
+                       "least a host failed.",
+        'env': 'BRIGADE_RAISE_ON_ERROR',
+        'type': bool,
+        'default': True,
     },
     'ssh_config_file': {
         'description': 'User ssh_config_file',
-        'environment': 'BRIGADE_SSH_CONFIG_FILE',
+        'env': 'BRIGADE_SSH_CONFIG_FILE',
+        'type': str,
         'default': os.path.join(os.path.expanduser("~"), ".ssh", "config"),
     },
 }
@@ -35,5 +47,15 @@ class Config:
     def _assign_properties(self, c):
 
         for p in CONF:
-            v = os.environ.get(CONF[p]['environment']) or c.get(p) or CONF[p]['default']
+            if CONF[p]['type'] == bool:
+                if os.environ.get(CONF[p]['env']) is not None:
+                    v = os.environ.get(CONF[p]['env'])
+                elif c.get(p) is not None:
+                    v = c.get(p)
+                else:
+                    v = CONF[p]['default']
+                v = ast.literal_eval(str(v).title())
+            else:
+                v = os.environ.get(CONF[p]['env']) or c.get(p) or CONF[p]['default']
+                v = CONF[p]['type'](v)
             setattr(self, p, v)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -1,8 +1,18 @@
 import os
+import yaml
 
-c = {
-    'ssh_config_file': os.environ.get('BRIGADE_SSH_CONFIG_FILE') or
-    os.path.join(os.path.expanduser("~"), ".ssh", "config"),
+
+CONF = {
+    'num_workers': {
+        'description': 'Number of Brigade worker processes',
+        'environment': 'BRIGADE_NUM_WORKERS',
+        'default': 20,
+    },
+    'ssh_config_file': {
+        'description': 'User ssh_config_file',
+        'environment': 'BRIGADE_SSH_CONFIG_FILE',
+        'default': os.path.join(os.path.expanduser("~"), ".ssh", "config"),
+    },
 }
 
 
@@ -12,5 +22,18 @@ class Config:
 
     """
 
-    def __init__(self):
-        self.ssh_config_file = c['ssh_config_file']
+    def __init__(self, config_file=None):
+
+        if config_file:
+            with open(config_file, 'r') as f:
+                c = yaml.load(f.read())
+        else:
+            c = {}
+
+        self._assign_properties(c)
+
+    def _assign_properties(self, c):
+
+        for p in CONF:
+            v = os.environ.get(CONF[p]['environment']) or c.get(p) or CONF[p]['default']
+            setattr(self, p, v)

--- a/brigade/plugins/tasks/connections/paramiko_connection.py
+++ b/brigade/plugins/tasks/connections/paramiko_connection.py
@@ -11,14 +11,12 @@ def paramiko_connection(task=None, host=None):
     if host is None:
         host = task.host
 
-    # TODO configurable
-    ssh_config_file = os.path.join(os.path.expanduser("~"), ".ssh", "config")
-
     client = paramiko.SSHClient()
     client._policy = paramiko.WarningPolicy()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     ssh_config = paramiko.SSHConfig()
+    ssh_config_file = task.brigade.config.ssh_config_file
     if os.path.exists(ssh_config_file):
         with open(ssh_config_file) as f:
             ssh_config.parse(f)

--- a/docs/_data_templates/configuration-parameters.j2
+++ b/docs/_data_templates/configuration-parameters.j2
@@ -14,7 +14,7 @@ Configuration Parameters
 		<th>Type</th>
 		<th>Default</th>
 			<tr>
-				<td>{{ v['env'] }}</td>
+				<td>{{ v['env'] or 'BRIGADE_' + k|upper }}</td>
 				<td>{{ v['type'] }}</td>
 				<td>{{ v['default_doc'] or v['default'] }}</td>
 			</tr>

--- a/docs/_data_templates/configuration-parameters.j2
+++ b/docs/_data_templates/configuration-parameters.j2
@@ -1,4 +1,4 @@
-Configuration Parameters
+The configuration parameters will be set by the :doc:`Brigade.core.configuration.Config </ref/api/configuration>` class.
 
 {% for k, v in params|dictsort %}
 ----------

--- a/docs/_data_templates/configuration-parameters.j2
+++ b/docs/_data_templates/configuration-parameters.j2
@@ -1,0 +1,25 @@
+Configuration Parameters
+
+{% for k, v in params|dictsort %}
+----------
+
+{{ k }}
+----------------------------------
+
+
+.. raw:: html
+
+	<table border="1" class="docutils">
+		<th>Environment variable</th>
+		<th>Type</th>
+		<th>Default</th>
+			<tr>
+				<td>{{ v['env'] }}</td>
+				<td>{{ v['type'] }}</td>
+				<td>{{ v['default_doc'] or v['default'] }}</td>
+			</tr>
+	</table>
+
+{{ v['description'] }}
+
+{% endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,12 @@
 #
 import os
 import sys
+from jinja2 import Environment, FileSystemLoader
 
 sys.path.insert(0, os.path.abspath('../'))
 
+
+from brigade.core.configuration import CONF # noqa
 
 # -- General configuration ------------------------------------------------
 
@@ -166,3 +169,24 @@ texinfo_documents = [
      author, 'brigade', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+
+def build_configuration_parameters(app):
+    """Create documentation for configuration parameters."""
+
+    env = Environment(loader=FileSystemLoader("./_data_templates"))
+    template_file = env.get_template("configuration-parameters.j2")
+    data = {}
+    data['params'] = CONF
+    rendered_template = template_file.render(**data)
+    output_dir = './ref/configuration/generated'
+    with open('{}/parameters.rst'.format(output_dir), 'w') as f:
+        f.write(rendered_template)
+
+
+def setup(app):
+    """Map methods to states of the documentation build."""
+    app.connect('builder-inited', build_configuration_parameters)
+
+
+build_configuration_parameters(None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.abspath('../'))
 from brigade.core.configuration import CONF # noqa
 
 # -- General configuration ------------------------------------------------
+BASEPATH = os.path.dirname(__file__)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
@@ -174,12 +175,12 @@ texinfo_documents = [
 def build_configuration_parameters(app):
     """Create documentation for configuration parameters."""
 
-    env = Environment(loader=FileSystemLoader("./_data_templates"))
+    env = Environment(loader=FileSystemLoader("{0}/_data_templates".format(BASEPATH)))
     template_file = env.get_template("configuration-parameters.j2")
     data = {}
     data['params'] = CONF
     rendered_template = template_file.render(**data)
-    output_dir = './ref/configuration/generated'
+    output_dir = '{0}/ref/configuration/generated'.format(BASEPATH)
     with open('{}/parameters.rst'.format(output_dir), 'w') as f:
         f.write(rendered_template)
 

--- a/docs/ref/api/configuration.rst
+++ b/docs/ref/api/configuration.rst
@@ -1,0 +1,9 @@
+Configuration
+#############
+
+
+.. autoclass:: brigade.core.configuration.Config
+   :members:
+   :undoc-members:
+
+The attributes for the Config object will be the Brigade configuration parameters. For a list of available parameters see :doc:`Brigade configuration parameters </ref/configuration/index>`

--- a/docs/ref/api/index.rst
+++ b/docs/ref/api/index.rst
@@ -6,6 +6,7 @@ Brigade API Reference
    :caption: Brigade API
 
    brigade
+   configuration
    inventory
    task
    exceptions

--- a/docs/ref/configuration/index.rst
+++ b/docs/ref/configuration/index.rst
@@ -1,4 +1,10 @@
 Brigade Configuration
 =====================
 
+Each configuration parameter are applied in the following order:
+
+1. Environment variable
+2. Parameter in configuration file / object
+3. Default value
+
 .. include:: generated/parameters.rst

--- a/docs/ref/configuration/index.rst
+++ b/docs/ref/configuration/index.rst
@@ -1,0 +1,4 @@
+Brigade Configuration
+=====================
+
+.. include:: generated/parameters.rst

--- a/docs/ref/index.rst
+++ b/docs/ref/index.rst
@@ -9,6 +9,12 @@ Reference Guides
 
 .. toctree::
    :maxdepth: 2
+   :caption: Configuration
+
+   configuration/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: Plugins
 
    tasks/index


### PR DESCRIPTION
Something like this could work regarding `ssh_connection` in #25.

Could also ship a SimpleYaml config plugin similar to the SimpleInventory one.

Currently one would access the variables with `task.brigade.config.ssh_config_file` which seems a bit long, so perhaps some shortcut is needed. 
