### PR TITLE
removing host from connection tasks as it's no longer needed

### DIFF
--- a/brigade/plugins/tasks/connections/napalm_connection.py
+++ b/brigade/plugins/tasks/connections/napalm_connection.py
@@ -1,28 +1,27 @@
 from napalm import get_network_driver
 
 
-def napalm_connection(task=None, host=None, timeout=60, optional_args=None):
+def napalm_connection(task=None, timeout=60, optional_args=None):
     """
     This tasks connects to the device using the NAPALM driver and sets the
     relevant connection.
 
     Arguments:
         timeout (int, optional): defaults to 60
-        optional_args (dict, optional): defaults to ``{"port": task.host["napalm_port"]}``
+        optional_args (dict, optional): defaults to ``{"port": task.host["network_api_port"]}``
     """
-    if host is None:
-        host = task.host
+    host = task.host
 
     parameters = {
-        "hostname": task.host.host,
-        "username": task.host.username,
-        "password": task.host.password,
+        "hostname": host.host,
+        "username": host.username,
+        "password": host.password,
         "timeout": timeout,
         "optional_args": optional_args or {},
     }
-    if "port" not in parameters["optional_args"] and task.host.network_api_port:
-        parameters["optional_args"]["port"] = task.host.network_api_port
-    network_driver = get_network_driver(task.host.nos)
+    if "port" not in parameters["optional_args"] and host.network_api_port:
+        parameters["optional_args"]["port"] = host.network_api_port
+    network_driver = get_network_driver(host.nos)
 
     host.connections["napalm"] = network_driver(**parameters)
     host.connections["napalm"].open()

--- a/brigade/plugins/tasks/connections/netmiko_connection.py
+++ b/brigade/plugins/tasks/connections/netmiko_connection.py
@@ -9,26 +9,13 @@ napalm_to_netmiko_map = {
 }
 
 
-def netmiko_connection(task=None, host=None, **netmiko_args):
+def netmiko_connection(task=None, **netmiko_args):
     """Connect to the host using Netmiko and set the relevant connection in the connection map.
 
     Arguments:
         **netmiko_args: All supported Netmiko ConnectHandler arguments
-
-    Note, both Netmiko and Brigade have a host argument. Use the ``netmiko_host`` argument to
-    pass in a host (if bypassing Brigade inventory).
     """
-    if host is None:
-        host = task.host
-
-    try:
-        host.host
-    except AttributeError:
-        msg = "Both Netmiko and Brigade have a host argument. Use the 'netmiko_host' argument " \
-              "or the 'ip' argument to specify a device to connect to (if not specifying in " \
-              "Brigade's inventory)."
-        raise AttributeError(msg)
-
+    host = task.host
     parameters = {
         "host": host.host,
         "username": host.username,

--- a/brigade/plugins/tasks/connections/netmiko_connection.py
+++ b/brigade/plugins/tasks/connections/netmiko_connection.py
@@ -27,10 +27,5 @@ def netmiko_connection(task=None, **netmiko_args):
         device_type = napalm_to_netmiko_map.get(host.nos, host.nos)
         parameters['device_type'] = device_type
 
-    # Both netmiko and brigade use host, allow passing of an alternately named host argument
-    if netmiko_args.get("netmiko_host"):
-        netmiko_host = netmiko_args.pop("netmiko_host")
-        netmiko_args['host'] = netmiko_host
-
     parameters.update(**netmiko_args)
     host.connections["netmiko"] = ConnectHandler(**parameters)

--- a/brigade/plugins/tasks/connections/paramiko_connection.py
+++ b/brigade/plugins/tasks/connections/paramiko_connection.py
@@ -3,13 +3,12 @@ import os
 import paramiko
 
 
-def paramiko_connection(task=None, host=None):
+def paramiko_connection(task=None):
     """
     This tasks connects to the device with paramiko to the device and sets the
     relevant connection.
     """
-    if host is None:
-        host = task.host
+    host = task.host
 
     # TODO configurable
     ssh_config_file = os.path.join(os.path.expanduser("~"), ".ssh", "config")


### PR DESCRIPTION
@ogenstad brought up that after moving the connection to a task `host` is no longer needed, which is true, so I am removing it. This also simplifies netmiko's connection as there is no longer a collision.

@ktbyers @ogenstad 