### PR TITLE
FOR DISCUSSION generic format string for parameters

### DIFF
--- a/brigade/core/task.py
+++ b/brigade/core/task.py
@@ -2,6 +2,7 @@ import logging
 from builtins import super
 
 from brigade.core.exceptions import BrigadeExecutionError
+from brigade.core.helpers import format_string
 
 logger = logging.getLogger("brigade")
 
@@ -36,7 +37,19 @@ class Task(object):
         self.host = host
         self.brigade = brigade
         self.dry_run = dry_run
-        return self.task(self, **self.params)
+
+        params = {}
+        for k, v in self.params.items():
+            if isinstance(v, str):
+                try:
+                    params[k] = format_string(v, self, **self.host)
+                except ValueError:
+                    # This happens if the string can't be formatted
+                    params[k] = v
+            else:
+                params[k] = v
+
+        return self.task(self, **params)
 
 
 class Result(object):

--- a/brigade/plugins/tasks/commands/command.py
+++ b/brigade/plugins/tasks/commands/command.py
@@ -4,7 +4,6 @@ import subprocess
 
 
 from brigade.core.exceptions import CommandError
-from brigade.core.helpers import format_string
 from brigade.core.task import Result
 
 
@@ -26,7 +25,6 @@ def command(task, command):
     Raises:
         :obj:`brigade.core.exceptions.CommandError`: when there is a command error
     """
-    command = format_string(command, task, **task.host)
     logger.debug("{}:local_cmd:{}".format(task.host, command))
     cmd = subprocess.Popen(shlex.split(command),
                            stdout=subprocess.PIPE,

--- a/brigade/plugins/tasks/data/load_json.py
+++ b/brigade/plugins/tasks/data/load_json.py
@@ -1,6 +1,5 @@
 import json
 
-from brigade.core.helpers import format_string
 from brigade.core.task import Result
 
 
@@ -15,7 +14,6 @@ def load_json(task, file):
         :obj:`brigade.core.task.Result`:
           * result (``dict``): dictionary with the contents of the file
     """
-    file = format_string(file, task)
     with open(file, 'r') as f:
         data = json.loads(f.read())
 

--- a/brigade/plugins/tasks/data/load_yaml.py
+++ b/brigade/plugins/tasks/data/load_yaml.py
@@ -1,4 +1,3 @@
-from brigade.core.helpers import format_string
 from brigade.core.task import Result
 
 
@@ -16,7 +15,6 @@ def load_yaml(task, file):
         :obj:`brigade.core.task.Result`:
           * result (``dict``): dictionary with the contents of the file
     """
-    file = format_string(file, task)
     with open(file, 'r') as f:
         data = yaml.load(f.read())
 

--- a/brigade/plugins/tasks/files/sftp.py
+++ b/brigade/plugins/tasks/files/sftp.py
@@ -4,7 +4,6 @@ import os
 import stat
 
 from brigade.core.exceptions import CommandError
-from brigade.core.helpers import format_string
 from brigade.core.task import Result
 from brigade.plugins.tasks import commands
 
@@ -124,8 +123,6 @@ def sftp(task, src, dst, action):
           * changed (``bool``):
           * files_changed (``list``): list of files that changed
     """
-    src = format_string(src, task, **task.host)
-    dst = format_string(dst, task, **task.host)
     actions = {
         "put": put,
         "get": get,

--- a/brigade/plugins/tasks/text/template_file.py
+++ b/brigade/plugins/tasks/text/template_file.py
@@ -1,4 +1,4 @@
-from brigade.core.helpers import format_string, jinja_helper, merge_two_dicts
+from brigade.core.helpers import jinja_helper, merge_two_dicts
 from brigade.core.task import Result
 
 
@@ -16,7 +16,6 @@ def template_file(task, template, path, **kwargs):
             * result (``string``): rendered string
     """
     merged = merge_two_dicts(task.host, kwargs)
-    path = format_string(path, task, **kwargs)
     text = jinja_helper.render_from_file(template=template, path=path,
                                          host=task.host, **merged)
     return Result(host=task.host, result=text)


### PR DESCRIPTION
As you can see from this PR some tasks allowed you to do things like:

```
brigade.run(commands.command,
            command="echo {host.name}")
```

Problem is that it was quite inconsistent. Some supported it while others didn't. So I started working on a generic solution for this and although it works I really don't like it as I think it's fragile and it's bound to break things eventually. I already had to handle `ValueError` exception because in one of my tests it was trying to format a junos configuration leading to an error...

So I was thinking in completely remove this functionality and change the pattern above for:

```
def echo_hostname(task):
    task.run(commands.command,
             command="echo {}".format(host.name))

brigade.run(echo_hostname)
```

Thoughts? Should we encourage this pattern or should we try to keep the old one (although inconsistent we can add as necessary) or should we try to make this generic mechanism for resilient? Maybe if we pass it to a jinja2 template it will be better? I think I personally prefer the `echo_hostname` pattern.