### PR TITLE
Only allow int, str and bool environment variables

### DIFF
--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -7,7 +7,7 @@ import yaml
 CONF = {
     'inventory': {
         'description': 'Path to inventory modules.',
-        'type': 'string',
+        'type': 'str',
         'default': 'brigade.plugins.inventory.simple.SimpleInventory',
     },
     'num_workers': {
@@ -103,8 +103,10 @@ class Config:
             return True
 
     def _assign_property(self, parameter, param_conf, data):
-        env = param_conf.get('env') or 'BRIGADE_' + parameter.upper()
-        v = os.environ.get(env)
+        v = None
+        if param_conf['type'] in ('bool', 'int', 'str'):
+            env = param_conf.get('env') or 'BRIGADE_' + parameter.upper()
+            v = os.environ.get(env)
         if v is None:
             v = data.get(parameter, param_conf["default"])
         else:

--- a/docs/_data_templates/configuration-parameters.j2
+++ b/docs/_data_templates/configuration-parameters.j2
@@ -14,7 +14,11 @@ The configuration parameters will be set by the :doc:`Brigade.core.configuration
 		<th>Type</th>
 		<th>Default</th>
 			<tr>
+			{% if v['type'] in ('str', 'int', 'bool') %}
 				<td>{{ v['env'] or 'BRIGADE_' + k|upper }}</td>
+			{% else %}
+				<td>N/A</td>
+			{% endif %}
 				<td>{{ v['type'] }}</td>
 				<td>{{ v['default_doc'] or v['default'] }}</td>
 			</tr>


### PR DESCRIPTION
The previous PR's introduced configuration types where the values can be
a list or a dictionary, this commit restricts the environment variables
so that only int, str and bool type settings can be configured using
environment variables.