### PR TITLE
Fix to simplify local testing with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ output/
 .DS_Store
 
 .pytest_cache/
+
+# Generated when testing
+nsot-docker.sqlite3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: start_nsot
 start_nsot:
-	docker run -v $(PWD)/tests/inventory_data/nsot/nsot.sqlite3:/nsot.sqlite3 -p 8990:8990 -d --name=nsot nsot/nsot start --noinput
+	cp $(PWD)/tests/inventory_data/nsot/nsot.sqlite3 $(PWD)/tests/inventory_data/nsot/nsot-docker.sqlite3
+	docker run -v $(PWD)/tests/inventory_data/nsot/nsot-docker.sqlite3:/nsot.sqlite3 -p 8990:8990 -d --name=nsot nsot/nsot start --noinput
 
 .PHONY: stop_nsot
 stop_nsot:


### PR DESCRIPTION
Currently the nsot.sqlite3 database always changes when running tests
this PR is a workaround where we instead copy the database to a
temporary file before starting the tests.