### PR TITLE
support more nsot parameters and auth_methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ output/
 .DS_Store
 
 .pytest_cache/
+
+.vscode

--- a/brigade/plugins/inventory/nsot.py
+++ b/brigade/plugins/inventory/nsot.py
@@ -25,7 +25,7 @@ class NSOTInventory(Inventory):
             for filtering hosts.
         nsot_url (string): URL to nsot's API (defaults to ``http://localhost:8990/api``)
         nsot_email (string): email for authtication (defaults to admin@acme.com)
-        nsot_auth_header (string): String for auth_header authentication
+        nsot_auth_header (string): String for auth_header authentication (defaults to X-NSoT-Email)
         nsot_secret_key (string): Secret Key for auth_token method. If given auth_token
             will be used as auth_metod.
     """

--- a/brigade/plugins/inventory/nsot.py
+++ b/brigade/plugins/inventory/nsot.py
@@ -15,25 +15,28 @@ class NSOTInventory(Inventory):
         the name of the site the host belongs to.
 
     Environment Variables:
-        * ``nsot_url``: URL to nsot's API (defaults to ``http://localhost:8990/api``)
-        * ``nsot_email``: email for authentication (defaults to admin@acme.com)
-        * ``nsot_auth_method``: auth_header or auth_token
-        * ``nsot_auth_header``: used for auth_header authentication method
-        * ``nsot_secret_key``: needed for auth_method = auth_token
+        * ``NSOT_URL``: Corresponds to nsot_url argument
+        * ``NSOT_EMAIL``: Corresponds to nsot_email argument
+        * ``NSOT_AUTH_HEADER``: Corresponds to nsot_auth_header argument
+        * ``NSOT_SECRET_KEY``: Corresponds to nsot_secret_key argument
 
     Arguments:
         flatten_attributes (bool): Assign host attributes to the root object. Useful
             for filtering hosts.
+        nsot_url (string): URL to nsot's API (defaults to ``http://localhost:8990/api``)
+        nsot_email (string): email for authtication (defaults to admin@acme.com)
+        nsot_auth_header (string): String for auth_header authentication
+        nsot_secret_key (string): Secret Key for auth_token method. If given auth_token
+            will be used as auth_metod.
     """
 
     def __init__(self, nsot_url="", nsot_email="", nsot_auth_method="",
                  nsot_secret_key="", nsot_auth_header="", flatten_attributes=True, **kwargs):
         nsot_url = nsot_url or os.environ.get('NSOT_URL', 'http://localhost:8990/api')
         nsot_email = nsot_email or os.environ.get('NSOT_EMAIL', 'admin@acme.com')
-        nsot_auth_method = nsot_auth_method or os.environ.get('NSOT_AUTH_METHOD', 'auth_header')
+        nsot_secret_key = nsot_secret_key or os.environ.get('NSOT_SECRET_KEY')
 
-        if nsot_auth_method == "auth_token":
-            nsot_secret_key = nsot_secret_key or os.environ.get('NSOT_SECRET_KEY', 'empty')
+        if nsot_secret_key:
             data = {'email': nsot_email, 'secret_key': nsot_secret_key}
             res = requests.post('{}/authenticate/'.format(nsot_url), data=data)
             auth_token = res.json().get('auth_token')

--- a/brigade/plugins/inventory/nsot.py
+++ b/brigade/plugins/inventory/nsot.py
@@ -27,7 +27,7 @@ class NSOTInventory(Inventory):
         nsot_email (string): email for authtication (defaults to admin@acme.com)
         nsot_auth_header (string): String for auth_header authentication (defaults to X-NSoT-Email)
         nsot_secret_key (string): Secret Key for auth_token method. If given auth_token
-            will be used as auth_metod.
+            will be used as auth_method.
     """
 
     def __init__(self, nsot_url="", nsot_email="", nsot_auth_method="",

--- a/brigade/plugins/inventory/nsot.py
+++ b/brigade/plugins/inventory/nsot.py
@@ -15,22 +15,38 @@ class NSOTInventory(Inventory):
         the name of the site the host belongs to.
 
     Environment Variables:
-        * ``NSOT_URL``: URL to nsot's API (defaults to ``http://localhost:8990/api``)
-        * ``NSOT_EMAIL``: email for authentication (defaults to admin@acme.com)
+        * ``nsot_url``: URL to nsot's API (defaults to ``http://localhost:8990/api``)
+        * ``nsot_email``: email for authentication (defaults to admin@acme.com)
+        * ``nsot_auth_method``: auth_header or auth_token
+        * ``nsot_auth_header``: used for auth_header authentication method
+        * ``nsot_secret_key``: needed for auth_method = auth_token
 
     Arguments:
         flatten_attributes (bool): Assign host attributes to the root object. Useful
             for filtering hosts.
     """
 
-    def __init__(self, flatten_attributes=True, **kwargs):
-        NSOT_URL = os.environ.get('NSOT_URL', 'http://localhost:8990/api')
-        NSOT_EMAIL = os.environ.get('NSOT_EMAIL', 'admin@acme.com')
+    def __init__(self, nsot_url="", nsot_email="", nsot_auth_method="",
+                 nsot_secret_key="", nsot_auth_header="", flatten_attributes=True, **kwargs):
+        nsot_url = nsot_url or os.environ.get('NSOT_URL', 'http://localhost:8990/api')
+        nsot_email = nsot_email or os.environ.get('NSOT_EMAIL', 'admin@acme.com')
+        nsot_auth_method = nsot_auth_method or os.environ.get('NSOT_AUTH_METHOD', 'auth_header')
 
-        headers = {'X-NSoT-Email': NSOT_EMAIL}
-        devices = requests.get('{}/devices'.format(NSOT_URL), headers=headers).json()
-        sites = requests.get('{}/sites'.format(NSOT_URL), headers=headers).json()
-        interfaces = requests.get('{}/interfaces'.format(NSOT_URL), headers=headers).json()
+        if nsot_auth_method == "auth_token":
+            nsot_secret_key = nsot_secret_key or os.environ.get('NSOT_SECRET_KEY', 'empty')
+            data = {'email': nsot_email, 'secret_key': nsot_secret_key}
+            res = requests.post('{}/authenticate/'.format(nsot_url), data=data)
+            auth_token = res.json().get('auth_token')
+            headers = {'Authorization': 'AuthToken {}:{}'.format(nsot_email, auth_token)}
+
+        else:
+            nsot_auth_header = nsot_auth_header or os.environ.get('NSOT_AUTH_HEADER',
+                                                                  'X-NSoT-Email')
+            headers = {nsot_auth_header: nsot_email}
+
+        devices = requests.get('{}/devices'.format(nsot_url), headers=headers).json()
+        sites = requests.get('{}/sites'.format(nsot_url), headers=headers).json()
+        interfaces = requests.get('{}/interfaces'.format(nsot_url), headers=headers).json()
 
         # We resolve site_id and assign "site" variable with the name of the site
         for d in devices:


### PR DESCRIPTION
I have added support for providing nsot parameters in config.yaml (and load it with InitBrigade). I also added support for additional nsot parameters, so that both auth_methods (auth_header/auth_token) can be used.