### PR TITLE
Transform function can be given as function arg (InitBrigade) or in config.yaml

### DIFF
--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -237,24 +237,10 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     """
     conf = Config(config_file=config_file, **kwargs)
 
-    module_path = ".".join(conf.inventory.split(".")[:-1])
-    inv_class_name = conf.inventory.split(".")[-1]
-    module = importlib.import_module(module_path)
-    inv_class = getattr(module, inv_class_name)
-    inv_class_args = getattr(conf, inv_class_name, {})
-
-    transform_function = kwargs.get("transform_function")
-
-    if callable(transform_function):
-        inv_class_args['transform_function'] = transform_function
-    else:
-        module_path = ".".join(conf.transform_function.split(".")[:-1])
-        transform_function_name = conf.transform_function.split(".")[-1]
-        module = importlib.import_module(module_path)
-        transform_function = getattr(module, transform_function_name)
-        inv_class_args['transform_function'] = transform_function
-
-    inv = inv_class(**inv_class_args)
+    inv_class = conf.inventory
+    inv_args = getattr(conf, inv_class.__name__, {})
+    transform_function = conf.transform_function
+    inv = inv_class(transform_function=transform_function, **inv_args)
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv = inv_class(**getattr(conf, inv_class_name, {}), **getattr(conf, 'transform_function', {}))
+    inv = inv_class(**getattr(conf, inv_class_name, {}), transform_function: conf.transform_function)
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -251,7 +251,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
         module_path = ".".join(conf.transform_function.split(".")[:-1])
         transform_function_name = conf.transform_function.split(".")[-1]
         module = importlib.import_module(module_path)
-        transform_function = getattr(module, tf_function_name)
+        transform_function = getattr(module, transform_function_name)
         inv_class_args['transform_function'] = transform_function
 
     inv = inv_class(**inv_class_args)

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    module_path = ".".join(config.transform_function.split("."))[:-1]
+    module_path = ".".join(conf.transform_function.split("."))[:-1]
     tf_function_name = conf.transform_function.split(".")[-1]
     module = importlibe.import_module(module_path)
     tf_function = getattr(module, tf_function_name)

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,8 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv = inv_class(**getattr(conf, inv_class_name, {}), 'transform_function': conf.transform_function)
+    inv_class_args = getattr(conf, inv_class_name, {}).update({'transform_function': conf.transform_function})
+    inv = inv_class(**inv_class_args)
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,8 +242,13 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
+    module_path = ".".join(config.transform_function.split("."))[:-1]
+    tf_function_name = conf.transform_function.split(".")[-1]
+    module = importlibe.import_module(module_path)
+    tf_function = getattr(module, tf_function_name)
+
     inv_class_args = getattr(conf, inv_class_name, {})
-    inv_class_args['transform_function'] = getattr(conf, 'transform_function', "")
+    inv_class_args['transform_function'] = tf_function
     inv = inv_class(**inv_class_args)
 
     return Brigade(

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -244,7 +244,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
 
     module_path = ".".join(conf.transform_function.split("."))[:-1]
     tf_function_name = conf.transform_function.split(".")[-1]
-    module = importlibe.import_module(module_path)
+    module = importlib.import_module(module_path)
     tf_function = getattr(module, tf_function_name)
 
     inv_class_args = getattr(conf, inv_class_name, {})

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import logging.config
 import sys

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,8 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv_class_args = getattr(conf, inv_class_name, {}).update({'transform_function': conf.transform_function})
-    inv = inv_class(**inv_class_args)
+    inv = inv_class(**getattr(conf, inv_class_name, {}).update({'transform_function': conf.transform_function}))
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -112,22 +112,22 @@ class Brigade(object):
             dictConfig["root"]["handlers"].append('info_file_handler')
             handlers_list.append('info_file_handler')
             dictConfig["handlers"]["info_file_handler"] = {
-                    "class": "logging.handlers.RotatingFileHandler",
-                    "level": "NOTSET",
-                    "formatter": "simple",
-                    "filename": self.config.logging_file,
-                    "maxBytes": 10485760,
-                    "backupCount": 20,
-                    "encoding": "utf8"
+                "class": "logging.handlers.RotatingFileHandler",
+                "level": "NOTSET",
+                "formatter": "simple",
+                "filename": self.config.logging_file,
+                "maxBytes": 10485760,
+                "backupCount": 20,
+                "encoding": "utf8"
             }
         if self.config.logging_to_console:
             dictConfig["root"]["handlers"].append('info_console')
             handlers_list.append('info_console')
             dictConfig["handlers"]["info_console"] = {
-                    "class": "logging.StreamHandler",
-                    "level": "NOTSET",
-                    "formatter": "simple",
-                    "stream": "ext://sys.stdout",
+                "class": "logging.StreamHandler",
+                "level": "NOTSET",
+                "formatter": "simple",
+                "stream": "ext://sys.stdout",
             }
 
         for logger in self.config.logging_loggers:
@@ -242,7 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv = inv_class(**getattr(conf, inv_class_name, {}))
+    inv = inv_class(**getattr(conf, inv_class_name, {}), **getattr(conf, 'transform_function', {}))
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -241,14 +241,17 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     inv_class_name = conf.inventory.split(".")[-1]
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
-
-    module_path = ".".join(conf.transform_function.split(".")[:-1])
-    tf_function_name = conf.transform_function.split(".")[-1]
-    module = importlib.import_module(module_path)
-    tf_function = getattr(module, tf_function_name)
-
     inv_class_args = getattr(conf, inv_class_name, {})
-    inv_class_args['transform_function'] = tf_function
+
+    if callable(transform_function):
+        inv_class_args['transform_function'] = transform_function
+    else:
+        module_path = ".".join(conf.transform_function.split(".")[:-1])
+        transform_function_name = conf.transform_function.split(".")[-1]
+        module = importlib.import_module(module_path)
+        transform_function = getattr(module, tf_function_name)
+        inv_class_args['transform_function'] = transform_function
+
     inv = inv_class(**inv_class_args)
 
     return Brigade(

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,9 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv = inv_class(**getattr(conf, inv_class_name, {}).update({'transform_function': conf.transform_function}))
+    mapping = getattr(conf, inv_class_name, {})
+    inv_class_args = mapping.update({'transform_function': conf.transform_function})
+    inv = inv_class(**inv_class_args)
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,8 +242,8 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    mapping = getattr(conf, inv_class_name, {})
-    inv_class_args = mapping.update({'transform_function': conf.transform_function})
+    inv_class_args = getattr(conf, inv_class_name, {})
+    inv_class_args['transform_function'] = getattr(conf, 'transform_function', "")
     inv = inv_class(**inv_class_args)
 
     return Brigade(

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -243,6 +243,8 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     inv_class = getattr(module, inv_class_name)
     inv_class_args = getattr(conf, inv_class_name, {})
 
+    transform_function = kwargs.get("transform_function")
+
     if callable(transform_function):
         inv_class_args['transform_function'] = transform_function
     else:

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    inv = inv_class(**getattr(conf, inv_class_name, {}), transform_function: conf.transform_function)
+    inv = inv_class(**getattr(conf, inv_class_name, {}), 'transform_function': conf.transform_function)
 
     return Brigade(
         inventory=inv,

--- a/brigade/core/__init__.py
+++ b/brigade/core/__init__.py
@@ -242,7 +242,7 @@ def InitBrigade(config_file="", dry_run=False, **kwargs):
     module = importlib.import_module(module_path)
     inv_class = getattr(module, inv_class_name)
 
-    module_path = ".".join(conf.transform_function.split("."))[:-1]
+    module_path = ".".join(conf.transform_function.split(".")[:-1])
     tf_function_name = conf.transform_function.split(".")[-1]
     module = importlib.import_module(module_path)
     tf_function = getattr(module, tf_function_name)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -10,6 +10,11 @@ CONF = {
         'type': 'str',
         'default': 'brigade.plugins.inventory.simple.SimpleInventory',
     },
+    'transform_function': {
+        'description': 'Path to transform function.',
+        'type': 'str',
+        'default': {}
+    },
     'num_workers': {
         'description': 'Number of Brigade worker processes that are run at the same time, '
                        'configuration can be overridden on individual tasks by using the '

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 
@@ -101,11 +102,13 @@ class Config:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-        inventory = self.resolve_import_from_string(kwargs.get("inventory"))
-        kwargs["inventory"] = inventory
+        inventory = (self._resolve_import_from_string(kwargs.get("inventory")) or
+                     self._resolve_import_from_string(self.inventory))
+        self.inventory = inventory
 
-        transform_function = self.resolve_import_from_string(kwargs.get("transform_function"))
-        kwargs["transform_function"] = transform_function
+        transform_function = (self._resolve_import_from_string(kwargs.get("transform_function")) or
+                              self._resolve_import_from_string(self.transform_function))
+        self.transform_function = transform_function
 
     def string_to_bool(self, v):
         if v.lower() in ["false", "no", "n", "off", "0"]:
@@ -152,7 +155,7 @@ class Config:
             value = types[str(parameter_type)](value)
         return value
 
-    def resolve_import_from_string(self, import_path):
+    def _resolve_import_from_string(self, import_path):
         """
         Resolves import from a string. Checks if callable or path is given.
 

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -105,7 +105,9 @@ class Config:
         inventory = self._resolve_import_from_string(kwargs.get("inventory", self.inventory))
         self.inventory = inventory
 
-        transform_function = self._resolve_import_from_string(kwargs.get("transform_function", self.transform_function))
+        transform_function = self._resolve_import_from_string(kwargs.get("transform_function",
+                                                                         self.transform_function,
+                                                                         ))
         self.transform_function = transform_function
 
     def string_to_bool(self, v):

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -101,6 +101,12 @@ class Config:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+        inventory = self.resolve_import_from_string(kwargs.get("inventory"))
+        kwargs["inventory"] = inventory
+
+        transform_function = self.resolve_import_from_string(kwargs.get("transform_function"))
+        kwargs["transform_function"] = transform_function
+
     def string_to_bool(self, v):
         if v.lower() in ["false", "no", "n", "off", "0"]:
             return False
@@ -145,3 +151,17 @@ class Config:
         else:
             value = types[str(parameter_type)](value)
         return value
+
+    def resolve_import_from_string(self, import_path):
+        """
+        Resolves import from a string. Checks if callable or path is given.
+
+        Arguments:
+            import_path(str): path of the import
+        """
+        if not import_path or callable(import_path):
+            return import_path
+        module_name = ".".join(import_path.split(".")[:-1])
+        obj_name = import_path.split(".")[-1]
+        module = importlib.import_module(module_name)
+        return getattr(module, obj_name)

--- a/brigade/core/configuration.py
+++ b/brigade/core/configuration.py
@@ -102,12 +102,10 @@ class Config:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-        inventory = (self._resolve_import_from_string(kwargs.get("inventory")) or
-                     self._resolve_import_from_string(self.inventory))
+        inventory = self._resolve_import_from_string(kwargs.get("inventory", self.inventory))
         self.inventory = inventory
 
-        transform_function = (self._resolve_import_from_string(kwargs.get("transform_function")) or
-                              self._resolve_import_from_string(self.transform_function))
+        transform_function = self._resolve_import_from_string(kwargs.get("transform_function", self.transform_function))
         self.transform_function = transform_function
 
     def string_to_bool(self, v):

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -76,11 +76,11 @@ class Test(object):
                           transform_function="tests.core.test_InitBrigade.transform_func",
                           )
         for host in brg.inventory.hosts:
-            assert host.data["transform_func"] == "executed"
+            assert brg.inventory.hosts.get(host).get("transform_func") == "executed"
 
     def test_InitBrigade_different_transform_function_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
                           transform_function=transform_func,
                           )
         for host in brg.inventory.hosts:
-            assert host.data["transform_func"] == "executed"
+            assert brg.inventory.hosts.get(host).get("transform_func") == "executed"

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -76,12 +76,12 @@ class Test(object):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
                           transform_function="tests.core.test_InitBrigade.transform_func",
                           )
-        for host in brg.inventory.hosts:
-            assert host.processed_by_transform_function
+        for value in brg.inventory.hosts.values():
+            assert value.processed_by_transform_function
 
     def test_InitBrigade_different_transform_function_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
                           transform_function=transform_func,
                           )
-        for host in brg.inventory.hosts:
-            assert host.processed_by_transform_function
+        for value in brg.inventory.hosts.values():
+            assert value.processed_by_transform_function

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -61,7 +61,7 @@ class Test(object):
 
     def test_InitBrigade_different_inventory_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          inventory="brigade.tests.core.test_InitBrigade.TestInventory",
+                          inventory="tests.core.test_InitBrigade.TestInventory",
                           )
         assert isinstance(brg.inventory, TestInventory)
 
@@ -73,7 +73,7 @@ class Test(object):
 
     def test_InitBrigade_different_transform_function_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          transform_function="brigade.tests.core.test_InitBrigade.transform_func",
+                          transform_function="tests.core.test_InitBrigade.transform_func",
                           )
         for host in brg.inventory.hosts:
             assert host.data["transform_func"] == "executed"

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -9,7 +9,7 @@ dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitB
 
 
 def transform_func(host):
-    host.data["transform_func"] = "executed"
+    host.processed_by_transform_function = True
 
 
 class TestInventory(Inventory):
@@ -77,11 +77,11 @@ class Test(object):
                           transform_function="tests.core.test_InitBrigade.transform_func",
                           )
         for host in brg.inventory.hosts:
-            assert brg.inventory.hosts.get(host).get("transform_func") == "executed"
+            assert host.processed_by_transform_function
 
     def test_InitBrigade_different_transform_function_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
                           transform_function=transform_func,
                           )
         for host in brg.inventory.hosts:
-            assert brg.inventory.hosts.get(host).get("transform_func") == "executed"
+            assert host.processed_by_transform_function

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -15,7 +15,8 @@ def transform_func(host):
 class TestInventory(Inventory):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        devices = {}
+        super().__init__(d, *args, **kwargs)
 
 
 class Test(object):

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,7 +1,7 @@
 import os
 
 from brigade.core import InitBrigade
-from brigade.core.plugins.inventory.nsot import NSOTInventory
+from brigade.plugins.inventory.nsot import NSOTInventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,7 +1,7 @@
 import os
 
 from brigade.core import InitBrigade
-from.brigade.core.plugins.inventory import NSOTInventory
+from brigade.core.plugins.inventory import NSOTInventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -7,8 +7,8 @@ from brigade.plugins.inventory.nsot import NSOTInventory
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")
 
 
-def test_transform_function(host):
-    host.data["transform_function_test"] = "executed"
+def transform_func(host):
+    host.data["transform_func"] = "executed"
 
 
 class Test(object):
@@ -66,14 +66,14 @@ class Test(object):
 
     def test_InitBrigade_different_transform_function_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          transform_function="brigade.tests.core.test_InitBrigade.test_transform_function",
+                          transform_function="brigade.tests.core.test_InitBrigade.transform_func",
                           )
         for host in brg.inventory.hosts:
-            assert host.data["transform_function_test"] == "executed"
+            assert host.data["transform_func"] == "executed"
 
     def test_InitBrigade_different_transform_function_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          transform_function=test_transform_function,
+                          transform_function=transform_func,
                           )
         for host in brg.inventory.hosts:
-            assert host.data["transform_function_test"] == "executed"
+            assert host.data["transform_func"] == "executed"

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -2,6 +2,7 @@ import os
 
 from builtins import super
 from brigade.core import InitBrigade
+from brigade.core.inventory import Inventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")
@@ -11,7 +12,7 @@ def transform_func(host):
     host.data["transform_func"] = "executed"
 
 
-class NSOTInventory:
+class NSOTInventory(Inventory):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -13,7 +13,7 @@ def transform_func(host):
 
 class NSOTInventory:
 
-    def __init__(self, *args, *kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
 

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,7 +1,7 @@
 import os
 
 from brigade.core import InitBrigade
-from brigade.core.plugins.inventory import NSOTInventory
+from brigade.core.plugins.inventory.nsot import NSOTInventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -15,8 +15,8 @@ def transform_func(host):
 class TestInventory(Inventory):
 
     def __init__(self, *args, **kwargs):
-        devices = {}
-        super().__init__(d, *args, **kwargs)
+        hosts = {"host1": {}, "host2": {}}
+        super().__init__(hosts, *args, **kwargs)
 
 
 class Test(object):

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,9 +1,14 @@
 import os
 
 from brigade.core import InitBrigade
+from.brigade.core.plugins.inventory import NSOTInventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")
+
+
+def test_transform_function(host):
+    host.data["transform_function_test"] = "executed"
 
 
 class Test(object):
@@ -29,10 +34,9 @@ class Test(object):
     def test_InitBrigade_programmatically(self):
         brg = InitBrigade(num_workers=100,
                           inventory="brigade.plugins.inventory.simple.SimpleInventory",
-                          SimpleInventory={
-                              "host_file": "tests/inventory_data/hosts.yaml",
-                              "group_file": "tests/inventory_data/groups.yaml",
-                              },
+                          SimpleInventory={"host_file": "tests/inventory_data/hosts.yaml",
+                                           "group_file": "tests/inventory_data/groups.yaml",
+                                           },
                           )
         assert not brg.dry_run
         assert brg.config.num_workers == 100
@@ -47,3 +51,29 @@ class Test(object):
         assert brg.config.num_workers == 200
         assert len(brg.inventory.hosts)
         assert len(brg.inventory.groups)
+
+    def test_InitBrigade_different_inventory_by_string(self):
+        brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
+                          inventory="brigade.plugins.inventory.nsot.NSOTInventory",
+                          )
+        assert isinstance(brg.inventory, NSOTInventory)
+
+    def test_InitBrigade_different_inventory_imported(self):
+        brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
+                          inventory=NSOTInventory,
+                          )
+        assert isinstance(brg.inventory, NSOTInventory)
+
+    def test_InitBrigade_different_transform_function_by_string(self):
+        brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
+                          transform_function="brigade.tests.core.test_InitBrigade.test_transform_function",
+                          )
+        for host in brg.inventory.hosts:
+            assert host.data["transform_function_test"] == "executed"
+
+    def test_InitBrigade_different_transform_function_imported(self):
+        brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
+                          transform_function=test_transform_function,
+                          )
+        for host in brg.inventory.hosts:
+            assert host.data["transform_function_test"] == "executed"

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -12,7 +12,7 @@ def transform_func(host):
     host.data["transform_func"] = "executed"
 
 
-class NSOTInventory(Inventory):
+class TestInventory(Inventory):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -61,15 +61,15 @@ class Test(object):
 
     def test_InitBrigade_different_inventory_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          inventory="brigade.plugins.inventory.nsot.NSOTInventory",
+                          inventory="brigade.tests.core.test_InitBrigade.TestInventory",
                           )
-        assert isinstance(brg.inventory, NSOTInventory)
+        assert isinstance(brg.inventory, TestInventory)
 
     def test_InitBrigade_different_inventory_imported(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),
-                          inventory=NSOTInventory,
+                          inventory=TestInventory,
                           )
-        assert isinstance(brg.inventory, NSOTInventory)
+        assert isinstance(brg.inventory, TestInventory)
 
     def test_InitBrigade_different_transform_function_by_string(self):
         brg = InitBrigade(config_file=os.path.join(dir_path, "a_config.yaml"),

--- a/tests/core/test_InitBrigade.py
+++ b/tests/core/test_InitBrigade.py
@@ -1,7 +1,7 @@
 import os
 
+from builtins import super
 from brigade.core import InitBrigade
-from brigade.plugins.inventory.nsot import NSOTInventory
 
 
 dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitBrigade")
@@ -9,6 +9,12 @@ dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitB
 
 def transform_func(host):
     host.data["transform_func"] = "executed"
+
+
+class NSOTInventory:
+
+    def __init__(self, *args, *kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class Test(object):


### PR DESCRIPTION
Hi,
as discussed I implemented the possibility to define a transform_function for an inventory (e.g. nsot) either as function arg of InitBrigade or directly in the config.yaml. 

Example of giving it in the config.yaml is:
transform_function: simon.test.transform_function.adapt_host_data

-> simon.test.transform_function has to be a module which could be imported. adapt_host_data() is the function.